### PR TITLE
CS32 Project 4 ("Pnetphlix") tweaks

### DIFF
--- a/cs32/pnetphlix/.gitignore
+++ b/cs32/pnetphlix/.gitignore
@@ -1,0 +1,1 @@
+/pnetphlix

--- a/cs32/pnetphlix/Makefile
+++ b/cs32/pnetphlix/Makefile
@@ -1,0 +1,2 @@
+pnetphlix: *.h *.cpp
+	c++ -o pnetphlix *.cpp

--- a/cs32/pnetphlix/Movie.cpp
+++ b/cs32/pnetphlix/Movie.cpp
@@ -19,35 +19,35 @@ Movie::Movie(const string& id, const string& title, const string& release_year,
 
 string Movie::get_id() const
 {
-    return m_id;  // Replace this line with correct code.
+    return m_id;
 }
 
 string Movie::get_title() const
 {
-    return m_title;  // Replace this line with correct code.
+    return m_title;
 }
 
 string Movie::get_release_year() const
 {
-    return m_releaseYear;  // Replace this line with correct code.
+    return m_releaseYear;
 }
 
 float Movie::get_rating() const
 {
-    return m_rating;  // Replace this line with correct code.
+    return m_rating;
 }
 
 vector<string> Movie::get_directors() const
 {
-    return m_directors;  // Replace this line with correct code.
+    return m_directors;
 }
 
 vector<string> Movie::get_actors() const
 {
-    return m_actors;  // Replace this line with correct code.
+    return m_actors;
 }
 
 vector<string> Movie::get_genres() const
 {
-    return m_genres;  // Replace this line with correct code.
+    return m_genres;
 }

--- a/cs32/pnetphlix/MovieDatabase.cpp
+++ b/cs32/pnetphlix/MovieDatabase.cpp
@@ -35,7 +35,6 @@ MovieDatabase::~MovieDatabase()
 
 bool MovieDatabase::load(const string& filename)
 {
-    //cout << "begin movie load" << endl;
     ifstream infile(filename);
 
     if (m_loaded == true) {
@@ -91,7 +90,6 @@ bool MovieDatabase::load(const string& filename)
         }
     }
     m_loaded = true;
-    //cout << "end movie load" << endl;
     return m_loaded;
 }
 

--- a/cs32/pnetphlix/MovieDatabase.cpp
+++ b/cs32/pnetphlix/MovieDatabase.cpp
@@ -23,7 +23,6 @@ vector<string> split(string s) {
 MovieDatabase::MovieDatabase()
 {
     m_loaded = false;
-    // Replace this line with correct code.
 }
 
 MovieDatabase::~MovieDatabase()
@@ -101,7 +100,7 @@ Movie* MovieDatabase::get_movie_from_id(const string& id) const
         return movie;
     }
     else {
-        return nullptr;  // Replace this line with correct code.
+        return nullptr;
     }
 }
 
@@ -114,7 +113,7 @@ vector<Movie*> MovieDatabase::get_movies_with_director(const string& director) c
         result.push_back(movie);
         it.advance();
     }
-    return result;  // Replace this line with correct code.
+    return result;
 }
 
 vector<Movie*> MovieDatabase::get_movies_with_actor(const string& actor) const
@@ -126,7 +125,7 @@ vector<Movie*> MovieDatabase::get_movies_with_actor(const string& actor) const
         result.push_back(movie);
         it.advance();
     }
-    return result;  // Replace this line with correct code.
+    return result;
 }
 
 vector<Movie*> MovieDatabase::get_movies_with_genre(const string& genre) const
@@ -138,5 +137,5 @@ vector<Movie*> MovieDatabase::get_movies_with_genre(const string& genre) const
         result.push_back(movie);
         it.advance();
     }
-    return result;  // Replace this line with correct code.
+    return result;
 }

--- a/cs32/pnetphlix/Recommender.cpp
+++ b/cs32/pnetphlix/Recommender.cpp
@@ -23,7 +23,6 @@ void addPoints(vector<MovieAndRank>& mandr, string mID, int points) {
 Recommender::Recommender(const UserDatabase& user_database,
                          const MovieDatabase& movie_database) : m_ud(user_database), m_md(movie_database)
 {
-    // Replace this line with correct code.
 }
 
 vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int movie_count) const
@@ -97,7 +96,7 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
         mandr.erase(mandr.begin() + movie_count, mandr.end());
     }
 
-    return mandr;  // Replace this line with correct code.
+    return mandr;
 }
 
 //===================================================================================

--- a/cs32/pnetphlix/Recommender.cpp
+++ b/cs32/pnetphlix/Recommender.cpp
@@ -48,6 +48,17 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
         for (int j = 0; j < directors.size(); j++) {
             const string& director = directors[j];
 
+            bool seen = false;
+            for (int jj = 0; jj < j; jj++) {
+              if (director == directors[jj]) {
+                seen = true;
+                break;
+              }
+            }
+            if (seen) {
+              continue;
+            }
+
             vector<Movie*> movies_from_director = m_md.get_movies_with_director(director);
             for (int k = 0; k < movies_from_director.size(); k++) {
                 addPoints(mandr, movies_from_director[k]->get_id(), 20);
@@ -58,6 +69,17 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
         for (int j = 0; j < actors.size(); j++) {
             const string& actor = actors[j];
 
+            bool seen = false;
+            for (int jj = 0; jj < j; jj++) {
+              if (actor == actors[jj]) {
+                seen = true;
+                break;
+              }
+            }
+            if (seen) {
+              continue;
+            }
+
             vector<Movie*> movies_from_actor = m_md.get_movies_with_actor(actor);
             for (int k = 0; k < movies_from_actor.size(); k++) {
                 addPoints(mandr, movies_from_actor[k]->get_id(), 30);
@@ -67,6 +89,17 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
         vector<string> genres = movie->get_genres();
         for (int j = 0; j < genres.size(); j++) {
             const string& genre = genres[j];
+
+            bool seen = false;
+            for (int jj = 0; jj < j; jj++) {
+              if (genre == genres[jj]) {
+                seen = true;
+                break;
+              }
+            }
+            if (seen) {
+              continue;
+            }
 
             vector<Movie*> movies_from_genre = m_md.get_movies_with_genre(genre);
             for (int k = 0; k < movies_from_genre.size(); k++) {

--- a/cs32/pnetphlix/Recommender.cpp
+++ b/cs32/pnetphlix/Recommender.cpp
@@ -9,7 +9,7 @@
 #include <iostream>
 using namespace std;
 
-void isCompatible(vector<MovieAndRank>& mandr, string mID, int points) {
+void addPoints(vector<MovieAndRank>& mandr, string mID, int points) {
     for (int i = 0; i < mandr.size(); i++) {
         if (mandr[i].movie_id == mID) {
             mandr[i].compatibility_score += points;
@@ -40,27 +40,38 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
     }
     vector<string> watchHistory = user->get_watch_history();
     for (int i = 0; i < watchHistory.size(); i++) {
+        const string& movie_id = watchHistory[i];
+
         cout << "new i loop iteration at i = " << i << endl;
-        Movie* movie = m_md.get_movie_from_id(watchHistory[i]);
+        Movie* movie = m_md.get_movie_from_id(movie_id);
+
         vector<string> directors = movie->get_directors();
         for (int j = 0; j < directors.size(); j++) {
-            vector<Movie*> movie_from_director = m_md.get_movies_with_director(directors[j]);
-            for (int k = 0; k < movie_from_director.size(); k++) {
-                isCompatible(mandr, movie_from_director[k]->get_id(), 20);
+            const string& director = directors[j];
+
+            vector<Movie*> movies_from_director = m_md.get_movies_with_director(director);
+            for (int k = 0; k < movies_from_director.size(); k++) {
+                addPoints(mandr, movies_from_director[k]->get_id(), 20);
             }
         }
+
         vector<string> actors = movie->get_actors();
         for (int j = 0; j < actors.size(); j++) {
-            vector<Movie*> movie_from_actor = m_md.get_movies_with_actor(actors[j]);
-            for (int k = 0; k < movie_from_actor.size(); k++) {
-                isCompatible(mandr, movie_from_actor[k]->get_id(), 30);
+            const string& actor = actors[j];
+
+            vector<Movie*> movies_from_actor = m_md.get_movies_with_actor(actor);
+            for (int k = 0; k < movies_from_actor.size(); k++) {
+                addPoints(mandr, movies_from_actor[k]->get_id(), 30);
             }
         }
+
         vector<string> genres = movie->get_genres();
         for (int j = 0; j < genres.size(); j++) {
-            vector<Movie*> movie_from_genre = m_md.get_movies_with_genre(genres[j]);
-            for (int k = 0; k < movie_from_genre.size(); k++) {
-                isCompatible(mandr, movie_from_genre[k]->get_id(), 1);
+            const string& genre = genres[j];
+
+            vector<Movie*> movies_from_genre = m_md.get_movies_with_genre(genre);
+            for (int k = 0; k < movies_from_genre.size(); k++) {
+                addPoints(mandr, movies_from_genre[k]->get_id(), 1);
             }
         }
     }

--- a/cs32/pnetphlix/Recommender.cpp
+++ b/cs32/pnetphlix/Recommender.cpp
@@ -10,7 +10,6 @@
 using namespace std;
 
 void isCompatible(vector<MovieAndRank>& mandr, string mID, int points) {
-    //cout << "in is compatible" << endl;
     for (int i = 0; i < mandr.size(); i++) {
         if (mandr[i].movie_id == mID) {
             mandr[i].compatibility_score += points;
@@ -29,17 +28,14 @@ Recommender::Recommender(const UserDatabase& user_database,
 
 vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int movie_count) const
 {
-    cout << "in recommend_movies function" << endl;
     vector<MovieAndRank> mandr;
 
     if (movie_count <= 0) {
-        cout << "movie count less than or equal to 0" << endl;
         return mandr;
     }
 
     User* user = m_ud.get_user_from_email(user_email);
     if (user == nullptr) {
-        cout << "invalid user" << endl;
         return mandr;
     }
     vector<string> watchHistory = user->get_watch_history();
@@ -76,7 +72,6 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
             if (watchHistory[j] == a.movie_id) {
                 i = mandr.erase(i);
                 erased = true;
-                cout << "removing duplicate" << endl;
                 break;
             }
         }
@@ -91,7 +86,6 @@ vector<MovieAndRank> Recommender::recommend_movies(const string& user_email, int
         mandr.erase(mandr.begin() + movie_count, mandr.end());
     }
 
-    cout << "end of function" << endl;
     return mandr;  // Replace this line with correct code.
 }
 

--- a/cs32/pnetphlix/Recommender.h
+++ b/cs32/pnetphlix/Recommender.h
@@ -28,7 +28,7 @@ class Recommender
   private:
       const UserDatabase& m_ud;
       const MovieDatabase& m_md;
-      bool compare(MovieAndRank i, MovieAndRank j);
+
       class Comparer {
       public:
           Comparer(const MovieDatabase& mdb) : m_md(mdb) {}

--- a/cs32/pnetphlix/UserDatabase.cpp
+++ b/cs32/pnetphlix/UserDatabase.cpp
@@ -9,7 +9,6 @@ using namespace std;
 UserDatabase::UserDatabase()
 {
     m_loaded = false;
-    // Replace this line with correct code.
 }
 
 UserDatabase::~UserDatabase()
@@ -60,7 +59,7 @@ bool UserDatabase::load(const string& filename)
     }
 
     m_loaded = true;
-    return m_loaded;  // Replace this line with correct code.
+    return m_loaded;
 }
 
 User* UserDatabase::get_user_from_email(const string& email) const
@@ -71,6 +70,6 @@ User* UserDatabase::get_user_from_email(const string& email) const
         return user;
     }
     else {
-        return nullptr;  // Replace this line with correct code.
+        return nullptr;
     }
 }

--- a/cs32/pnetphlix/UserDatabase.cpp
+++ b/cs32/pnetphlix/UserDatabase.cpp
@@ -21,7 +21,6 @@ UserDatabase::~UserDatabase()
 
 bool UserDatabase::load(const string& filename)
 {
-    //cout << "begin user load" << endl;
     ifstream infile(filename);
 
     if (m_loaded == true) {
@@ -50,12 +49,10 @@ bool UserDatabase::load(const string& filename)
 
         User* user = new User(name, email, watchHistory);
 
-        //cout << email << endl;
         m_users.insert(email, user);
         m_death.push_back(user);
 
         string blank;
-        //cout << blank << endl;
         if (!getline(infile, blank)) {
             break;
         }
@@ -63,7 +60,6 @@ bool UserDatabase::load(const string& filename)
     }
 
     m_loaded = true;
-    //cout << "end user load" << endl;
     return m_loaded;  // Replace this line with correct code.
 }
 

--- a/cs32/pnetphlix/main.cpp
+++ b/cs32/pnetphlix/main.cpp
@@ -20,7 +20,7 @@ using namespace std;
 
 
   // If your program is having trouble finding these files. replace the
-  // string literals with full path names to the files.  Also, for test
+  // string literals with full path names to the files.	 Also, for test
   // purposes, you may want to create some small, simple user and movie
   // data files to makde debuggiing easier, so you can replace the string
   // literals with the names of those smaller files.
@@ -37,7 +37,7 @@ int main()
 		return 1;
 	}
 	MovieDatabase mdb;
-	if (!mdb.load(MOVIE_DATAFILE))  // In skeleton, load always return false
+	if (!mdb.load(MOVIE_DATAFILE))	// In skeleton, load always return false
 	{
 		cout << "Failed to load user data file " << MOVIE_DATAFILE << "!" << endl;
 		return 1;
@@ -47,19 +47,20 @@ int main()
 	{
 		cout << "Enter user email address (or quit): ";
 		string email;
-		getline(cin, email);
-		if (email == "quit")
+		if (!getline(cin, email) || email == "quit")
 			return 0;
 		User* u = udb.get_user_from_email(email);
-		if (u == nullptr)
+		if (u == nullptr) {
 			cout << "No user in the database has that email address." << endl;
-		else
-			cout << "Found " << u->get_full_name() << endl;
+			continue;
+		}
+		cout << "Found " << u->get_full_name() << endl;
 
 		vector<MovieAndRank> mandr = r.recommend_movies(email, 5);
 		for (int i = 0; i < mandr.size(); i++) {
-			cout << mandr[i].movie_id << endl;
-			cout << mandr[i].compatibility_score << endl;
+			const MovieAndRank& mr = mandr[i];
+			const Movie* m = mdb.get_movie_from_id(mr.movie_id);
+			cout << m->get_title() << ", id=" << m->get_id(), << ", score=" << mr.compatibility_score << endl;
 		}
 	}
 }

--- a/cs32/pnetphlix/main.cpp
+++ b/cs32/pnetphlix/main.cpp
@@ -60,7 +60,7 @@ int main()
 		for (int i = 0; i < mandr.size(); i++) {
 			const MovieAndRank& mr = mandr[i];
 			const Movie* m = mdb.get_movie_from_id(mr.movie_id);
-			cout << m->get_title() << ", id=" << m->get_id(), << ", score=" << mr.compatibility_score << endl;
+			cout << m->get_title() << ", id=" << m->get_id() << ", score=" << mr.compatibility_score << endl;
 		}
 	}
 }

--- a/cs32/pnetphlix/treemm.h
+++ b/cs32/pnetphlix/treemm.h
@@ -16,7 +16,6 @@ class TreeMultimap
         {
             m_withVector = false;
             m_it = m_end;
-            // Replace this line with correct code.
         }
 
         Iterator(vector<ValueType>& v) {
@@ -28,7 +27,6 @@ class TreeMultimap
         ValueType& get_value() const
         {
             return *m_it;
-            //throw 1;  // Replace this line with correct code.
         }
 
         bool is_valid() const
@@ -48,7 +46,6 @@ class TreeMultimap
         void advance()
         {
             m_it++;
-            // Replace this line with correct code.
         }
 
       private:
@@ -60,13 +57,11 @@ class TreeMultimap
     TreeMultimap()
     {
         m_root = nullptr;
-        // Replace this line with correct code.
     }
 
     ~TreeMultimap()
     {
         delete_helper(m_root);
-        // Replace this line with correct code.
     }
 
     void insert(const KeyType& key, const ValueType& value)
@@ -88,7 +83,6 @@ class TreeMultimap
         else {
             insert_node->m_right = new Node(key, value);
         }
-        // Replace this line with correct code.
     }
 
     Iterator find(const KeyType& key) const
@@ -105,7 +99,7 @@ class TreeMultimap
             it = Iterator(cur->m_values);
         }
 
-        return it;  // Replace this line with correct code.
+        return it;
     }
 
   private:


### PR DESCRIPTION
This PR starts with the version of Pnetphlix from Friday evening, 10 March, and makes some cosmetic changes, like removing "Replace" comments, adding and renaming a few identifiers, and altering the output format for recommendations. It also makes one important correctness change: not scoring movies more than once for the same director, actor, or genre.

An upcoming change will also fix the performance bottleneck in `addPoints` (formerly `isCompatible`).

Use [the Commits tab](https://github.com/bobg/jonah/pull/1/commits) to see each individual change made.